### PR TITLE
Enable macos build

### DIFF
--- a/src/rmagine_core/CMakeLists.txt
+++ b/src/rmagine_core/CMakeLists.txt
@@ -34,11 +34,14 @@ target_include_directories(rmagine-core
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/rmagine-${rmagine_VERSION}>
     ${ASSIMP_INCLUDE_DIRS}
+    ${Boost_INCLUDE_DIRS}
 )
 
 target_link_libraries(rmagine-core
     ${ASSIMP_LIBRARIES}
     Eigen3::Eigen
+    ${Boost_LIBRARIES}
+    ${OpenMP_CXX_LIBRARIES}
 )
 
 target_compile_features(rmagine-core PRIVATE cxx_std_17)


### PR DESCRIPTION
These changes were needed for me to build this on macos ARM.

Had to `brew install assimp embree` as well.