### PR TITLE
CMake: Small fixes for boost, assimp and cuda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ if(CUDA_FOUND)
     endif(OptiX_FOUND)
 endif(CUDA_FOUND)
 
-message(STATUS "${BoldCyan}Components build:${ColourReset}")
+message(STATUS "${BoldCyan}Components being built:${ColourReset}")
 foreach(LIBRARY ${RMAGINE_LIBRARIES})
     message(STATUS "- ${BoldGreen}${LIBRARY}${ColourReset}")
 endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 ################################
 ## REQUIRED DEPS
 
-find_package(Boost REQUIRED)
+find_package(Boost CONFIG REQUIRED)
 find_package(Eigen3 REQUIRED)
 
 ############################

--- a/src/rmagine_core/CMakeLists.txt
+++ b/src/rmagine_core/CMakeLists.txt
@@ -36,16 +36,22 @@ target_include_directories(rmagine-core
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/rmagine-${rmagine_VERSION}>
-    ${ASSIMP_INCLUDE_DIRS}
     ${Boost_INCLUDE_DIRS}
 )
 
 target_link_libraries(rmagine-core
-    ${ASSIMP_LIBRARIES}
     Eigen3::Eigen
     ${Boost_LIBRARIES}
     ${OpenMP_CXX_LIBRARIES}
 )
+
+# prefer to link to assimp alias target
+if (TARGET assimp::assimp)
+  target_link_libraries(rmagine-core assimp::assimp)
+else()
+  target_include_directories(rmagine-core PUBLIC ${ASSIMP_INCLUDE_DIRS})
+  target_link_libraries(rmagine-core ${ASSIMP_LIBRARIES})
+endif()
 
 set_target_properties(rmagine-core
   PROPERTIES

--- a/src/rmagine_core/CMakeLists.txt
+++ b/src/rmagine_core/CMakeLists.txt
@@ -45,12 +45,12 @@ target_link_libraries(rmagine-core
     ${OpenMP_CXX_LIBRARIES}
 )
 
-# prefer to link to assimp alias target
-if (TARGET assimp::assimp)
-  target_link_libraries(rmagine-core assimp::assimp)
-else()
+# link to assimp::assimp when its library and include dir vars are missing
+if (DEFINED ASSIMP_INCLUDE_DIRS AND DEFINED ASSIMP_LIBRARIES)
   target_include_directories(rmagine-core PUBLIC ${ASSIMP_INCLUDE_DIRS})
   target_link_libraries(rmagine-core ${ASSIMP_LIBRARIES})
+else()
+  target_link_libraries(rmagine-core assimp::assimp)
 endif()
 
 set_target_properties(rmagine-core

--- a/src/rmagine_cuda/CMakeLists.txt
+++ b/src/rmagine_cuda/CMakeLists.txt
@@ -63,10 +63,14 @@ set_target_properties(rmagine-cuda
         SOVERSION ${rmagine_VERSION_MAJOR}
         VERSION ${rmagine_VERSION}
         CUDA_SEPARABLE_COMPILATION ON
-        # CUDA_ARCHITECTURES all
         # CUDA_STANDARD 17 -> only works for 
         # CXX_STANDARD 17
 )
+
+# set CUDA_ARCHITECTURES with CMake >= 3.23 when CMAKE_* is not set
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.23" AND NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    set_target_properties(rmagine-cuda PROPERTIES CUDA_ARCHITECTURES all)
+endif()
 
 add_library(rmagine::cuda ALIAS rmagine-cuda)
 


### PR DESCRIPTION
- set `CUDA_ARCHITECTURES` property with CMake >= 3.23 while still respecting the `CMAKE_*` var if set
- find boost in `CONFIG` mode as [preferred](https://cmake.org/cmake/help/latest/module/FindBoost.html) by CMake (available since Boost 1.70)
- linking `rmagine-core` against specific `assimp::assimp` target, as `ASSIMP_INCLUDE_DIRS` and `ASSIMP_LIBRARIES` were not defined in my case (Assimp v5.4.3). The latter two are still used as a fallback, should the alias target be missing
- changed cmake message from `Components build:` to `Components being built:`, as it is still the configure stage, not the build stage