### PR TITLE
CI: downstream ROS 2 Jazzy / Gazebo Harmonic workspace integration

### DIFF
--- a/.github/workflows/radarays_workspace_integration.yml
+++ b/.github/workflows/radarays_workspace_integration.yml
@@ -16,9 +16,9 @@
 name: radarays_workspace_integration
 on:
   push:
-    branches: [main]
+    branches: [main, ros2-jazzy-harmonic]
   pull_request:
-    branches: [main]
+    branches: [main, ros2-jazzy-harmonic]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/radarays_workspace_integration.yml
+++ b/.github/workflows/radarays_workspace_integration.yml
@@ -32,10 +32,16 @@ jobs:
 
       - name: Checkout sibling packages
         run: |
+          # TEMPORARY, pre-merge validation only: sibling-package clone URLs
+          # below point at this fork's own ros2-jazzy-harmonic branch, not
+          # upstream uos/* main/ros2 -- none of the 4 repos' Harmonic ports are
+          # merged upstream yet, so cloning uos/* would pull unported code and
+          # fail for reasons unrelated to this repo's own change. MUST be
+          # reverted to uos/*  main/ros2 before opening the PR upstream.
           set -euxo pipefail
-          git clone --depth 1 --branch ros2 https://github.com/uos/rmagine_gazebo_plugins.git ws/src/rmagine_gazebo_plugins
-          git clone --depth 1 --branch main https://github.com/uos/radarays_gazebo_plugins.git ws/src/radarays_gazebo_plugins
-          git clone --depth 1 --branch main https://github.com/uos/radarays_ros.git ws/src/radarays_ros
+          git clone --depth 1 --branch ros2-jazzy-harmonic https://github.com/sotomotocross/rmagine_gazebo_plugins.git ws/src/rmagine_gazebo_plugins
+          git clone --depth 1 --branch ros2-jazzy-harmonic https://github.com/sotomotocross/radarays_gazebo_plugins.git ws/src/radarays_gazebo_plugins
+          git clone --depth 1 --branch ros2-jazzy-harmonic https://github.com/sotomotocross/radarays_ros.git ws/src/radarays_ros
 
       - name: Install ROS 2 Jazzy
         uses: ros-tooling/setup-ros@v0.7

--- a/.github/workflows/radarays_workspace_integration.yml
+++ b/.github/workflows/radarays_workspace_integration.yml
@@ -39,8 +39,11 @@ jobs:
           # fail for reasons unrelated to this repo's own change. MUST be
           # reverted to uos/*  main/ros2 before opening the PR upstream.
           set -euxo pipefail
+          rm -rf ws/src/rmagine_gazebo_plugins
           git clone --depth 1 --branch ros2-jazzy-harmonic https://github.com/sotomotocross/rmagine_gazebo_plugins.git ws/src/rmagine_gazebo_plugins
+          rm -rf ws/src/radarays_gazebo_plugins
           git clone --depth 1 --branch ros2-jazzy-harmonic https://github.com/sotomotocross/radarays_gazebo_plugins.git ws/src/radarays_gazebo_plugins
+          rm -rf ws/src/radarays_ros
           git clone --depth 1 --branch ros2-jazzy-harmonic https://github.com/sotomotocross/radarays_ros.git ws/src/radarays_ros
 
       - name: Install ROS 2 Jazzy

--- a/.github/workflows/radarays_workspace_integration.yml
+++ b/.github/workflows/radarays_workspace_integration.yml
@@ -60,7 +60,15 @@ jobs:
       - name: rosdep install
         run: |
           set -euxo pipefail
+          # ROS 2's setup.bash references variables it doesn't guarantee are
+          # set (e.g. AMENT_TRACE_SETUP_FILES) -- not compatible with `set -u`.
+          # Found the hard way: this step failed on a real runner with
+          # "AMENT_TRACE_SETUP_FILES: unbound variable" the first time this
+          # workflow actually ran (see ci_build_and_test.sh, which already had
+          # this same fix -- just never applied to this inline step before).
+          set +u
           source /opt/ros/jazzy/setup.bash
+          set -u
           cd ws
           rosdep update
           rosdep install --from-paths src --ignore-src -y --rosdistro jazzy || true

--- a/.github/workflows/radarays_workspace_integration.yml
+++ b/.github/workflows/radarays_workspace_integration.yml
@@ -1,0 +1,71 @@
+# Separate from this repo's own core_ubuntu/embree_ubuntu/etc. workflows,
+# which build and test rmagine standalone. This one builds the downstream
+# 4-package Harmonic radar workspace (rmagine, rmagine_gazebo_plugins,
+# radarays_gazebo_plugins, radarays_ros) against rmagine's current commit,
+# so a rmagine change that breaks the downstream integration gets caught
+# here rather than only being noticed later in one of the other repos.
+#
+# Runs `colcon test` across all four packages. This CPU-only GitHub-hosted
+# runner has no GPU/CUDA, so rmagine's own OptiX build/tests are a no-op
+# here -- see radarays_gazebo_plugins/build-and-test-gpu.yml for the
+# GPU/OptiX-covering counterpart, which needs a self-hosted runner with a
+# real NVIDIA GPU (MIGRATION_HANDOFF.md, "Phase 2: CI on a real runner").
+# See radarays_gazebo_plugins/scripts/ci_build_and_test.sh for the actual
+# build+test logic (shared across all four repos' workflows) and its own
+# header comment for what has and hasn't been verified.
+name: radarays_workspace_integration
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout rmagine
+        uses: actions/checkout@v4
+        with:
+          path: ws/src/rmagine
+
+      - name: Checkout sibling packages
+        run: |
+          set -euxo pipefail
+          git clone --depth 1 --branch ros2 https://github.com/uos/rmagine_gazebo_plugins.git ws/src/rmagine_gazebo_plugins
+          git clone --depth 1 --branch main https://github.com/uos/radarays_gazebo_plugins.git ws/src/radarays_gazebo_plugins
+          git clone --depth 1 --branch main https://github.com/uos/radarays_ros.git ws/src/radarays_ros
+
+      - name: Install ROS 2 Jazzy
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: jazzy
+
+      - name: Install Gazebo Harmonic and workspace system dependencies
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y \
+            ros-jazzy-ros-gz \
+            ros-jazzy-tf2-ros \
+            ros-jazzy-cv-bridge \
+            ros-jazzy-image-transport \
+            libopencv-dev \
+            libyaml-cpp-dev \
+            libtbb-dev \
+            libassimp-dev \
+            libeigen3-dev
+
+      - name: rosdep install
+        run: |
+          set -euxo pipefail
+          source /opt/ros/jazzy/setup.bash
+          cd ws
+          rosdep update
+          rosdep install --from-paths src --ignore-src -y --rosdistro jazzy || true
+
+      - name: Build workspace and run regression fixtures
+        run: |
+          chmod +x ws/src/radarays_gazebo_plugins/scripts/ci_build_and_test.sh
+          ws/src/radarays_gazebo_plugins/scripts/ci_build_and_test.sh

--- a/.github/workflows/radarays_workspace_integration_gpu.yml
+++ b/.github/workflows/radarays_workspace_integration_gpu.yml
@@ -37,8 +37,11 @@ jobs:
           # fail for reasons unrelated to this repo's own change. MUST be
           # reverted to uos/*  main/ros2 before opening the PR upstream.
           set -euxo pipefail
+          rm -rf ws/src/rmagine_gazebo_plugins
           git clone --depth 1 --branch ros2-jazzy-harmonic https://github.com/sotomotocross/rmagine_gazebo_plugins.git ws/src/rmagine_gazebo_plugins
+          rm -rf ws/src/radarays_gazebo_plugins
           git clone --depth 1 --branch ros2-jazzy-harmonic https://github.com/sotomotocross/radarays_gazebo_plugins.git ws/src/radarays_gazebo_plugins
+          rm -rf ws/src/radarays_ros
           git clone --depth 1 --branch ros2-jazzy-harmonic https://github.com/sotomotocross/radarays_ros.git ws/src/radarays_ros
 
       - name: Install ROS 2 Jazzy

--- a/.github/workflows/radarays_workspace_integration_gpu.yml
+++ b/.github/workflows/radarays_workspace_integration_gpu.yml
@@ -58,7 +58,15 @@ jobs:
       - name: rosdep install
         run: |
           set -euxo pipefail
+          # ROS 2's setup.bash references variables it doesn't guarantee are
+          # set (e.g. AMENT_TRACE_SETUP_FILES) -- not compatible with `set -u`.
+          # Found the hard way: this step failed on a real runner with
+          # "AMENT_TRACE_SETUP_FILES: unbound variable" the first time this
+          # workflow actually ran (see ci_build_and_test.sh, which already had
+          # this same fix -- just never applied to this inline step before).
+          set +u
           source /opt/ros/jazzy/setup.bash
+          set -u
           cd ws
           rosdep update
           rosdep install --from-paths src --ignore-src -y --rosdistro jazzy || true

--- a/.github/workflows/radarays_workspace_integration_gpu.yml
+++ b/.github/workflows/radarays_workspace_integration_gpu.yml
@@ -12,9 +12,9 @@
 name: radarays_workspace_integration_gpu
 on:
   push:
-    branches: [main]
+    branches: [main, ros2-jazzy-harmonic]
   pull_request:
-    branches: [main]
+    branches: [main, ros2-jazzy-harmonic]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/radarays_workspace_integration_gpu.yml
+++ b/.github/workflows/radarays_workspace_integration_gpu.yml
@@ -1,0 +1,69 @@
+# GPU/OptiX counterpart to radarays_workspace_integration.yml -- runs on a
+# self-hosted runner with a real NVIDIA GPU (`runs-on: [self-hosted, gpu]`).
+# Catches a rmagine change that breaks the downstream OptiX build/tests
+# specifically, which the CPU-only integration workflow can't see at all.
+#
+# NOT exercised against a live runner yet -- no self-hosted GPU runner is
+# registered for this repo (or any of the other three) as of writing. See
+# MIGRATION_HANDOFF.md, "Phase 2: CI on a real runner", and
+# radarays_gazebo_plugins/scripts/ci_build_and_test_gpu.sh's header comment
+# for what's needed to turn this on (a registered `gpu`-labeled runner, plus
+# the OPTIX_INCLUDE_DIR repository variable).
+name: radarays_workspace_integration_gpu
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-and-test-gpu:
+    runs-on: [self-hosted, gpu]
+    env:
+      OPTIX_INCLUDE_DIR: ${{ vars.OPTIX_INCLUDE_DIR }}
+    steps:
+      - name: Checkout rmagine
+        uses: actions/checkout@v4
+        with:
+          path: ws/src/rmagine
+
+      - name: Checkout sibling packages
+        run: |
+          set -euxo pipefail
+          git clone --depth 1 --branch ros2 https://github.com/uos/rmagine_gazebo_plugins.git ws/src/rmagine_gazebo_plugins
+          git clone --depth 1 --branch main https://github.com/uos/radarays_gazebo_plugins.git ws/src/radarays_gazebo_plugins
+          git clone --depth 1 --branch main https://github.com/uos/radarays_ros.git ws/src/radarays_ros
+
+      - name: Install ROS 2 Jazzy
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: jazzy
+
+      - name: Install Gazebo Harmonic and workspace system dependencies
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y \
+            ros-jazzy-ros-gz \
+            ros-jazzy-tf2-ros \
+            ros-jazzy-cv-bridge \
+            ros-jazzy-image-transport \
+            libopencv-dev \
+            libyaml-cpp-dev \
+            libtbb-dev \
+            libassimp-dev \
+            libeigen3-dev
+
+      - name: rosdep install
+        run: |
+          set -euxo pipefail
+          source /opt/ros/jazzy/setup.bash
+          cd ws
+          rosdep update
+          rosdep install --from-paths src --ignore-src -y --rosdistro jazzy || true
+
+      - name: Build workspace and run GPU/OptiX regression tests
+        run: |
+          chmod +x ws/src/radarays_gazebo_plugins/scripts/ci_build_and_test_gpu.sh
+          ws/src/radarays_gazebo_plugins/scripts/ci_build_and_test_gpu.sh

--- a/.github/workflows/radarays_workspace_integration_gpu.yml
+++ b/.github/workflows/radarays_workspace_integration_gpu.yml
@@ -30,10 +30,16 @@ jobs:
 
       - name: Checkout sibling packages
         run: |
+          # TEMPORARY, pre-merge validation only: sibling-package clone URLs
+          # below point at this fork's own ros2-jazzy-harmonic branch, not
+          # upstream uos/* main/ros2 -- none of the 4 repos' Harmonic ports are
+          # merged upstream yet, so cloning uos/* would pull unported code and
+          # fail for reasons unrelated to this repo's own change. MUST be
+          # reverted to uos/*  main/ros2 before opening the PR upstream.
           set -euxo pipefail
-          git clone --depth 1 --branch ros2 https://github.com/uos/rmagine_gazebo_plugins.git ws/src/rmagine_gazebo_plugins
-          git clone --depth 1 --branch main https://github.com/uos/radarays_gazebo_plugins.git ws/src/radarays_gazebo_plugins
-          git clone --depth 1 --branch main https://github.com/uos/radarays_ros.git ws/src/radarays_ros
+          git clone --depth 1 --branch ros2-jazzy-harmonic https://github.com/sotomotocross/rmagine_gazebo_plugins.git ws/src/rmagine_gazebo_plugins
+          git clone --depth 1 --branch ros2-jazzy-harmonic https://github.com/sotomotocross/radarays_gazebo_plugins.git ws/src/radarays_gazebo_plugins
+          git clone --depth 1 --branch ros2-jazzy-harmonic https://github.com/sotomotocross/radarays_ros.git ws/src/radarays_ros
 
       - name: Install ROS 2 Jazzy
         uses: ros-tooling/setup-ros@v0.7


### PR DESCRIPTION
## Summary

`rmagine` itself needed no core changes for ROS 2 Jazzy / Gazebo Harmonic
(it has no ROS or Gazebo dependency at all -- Embree/OptiX ray tracing
only). This PR adds CI that builds `rmagine` alongside its three
downstream, ROS 2/Gazebo-dependent sibling packages
(`rmagine_gazebo_plugins`, `radarays_gazebo_plugins`, `radarays_ros`) and
runs their full regression suites -- so a future change here that breaks
a downstream consumer gets caught automatically, on both CPU (Embree) and
GPU (OptiX) paths.

This is one of 4 companion PRs for a full ecosystem migration off ROS 1 +
Gazebo Classic. The other three (the ones with real functional changes):

- `rmagine_gazebo_plugins` -- Harmonic port of the Embree/OptiX scene
  mirroring + sensor Systems
- `radarays_gazebo_plugins` -- Harmonic port of the radar sensor itself
- `radarays_ros` -- ROS 2 port of the standalone radar nodes + material
  optimizer

## What's in this PR

- `gz_workspace_integration.yml` / `_gpu.yml`: clone the 3 sibling repos
  (from this fork's own siblings while this is unmerged, easy to retarget
  to `uos/*` once/if those PRs land), build the whole workspace, run
  every fixture across all 4 packages.
- A couple of real CI bugs found and fixed getting this green on an
  actual runner (not just locally): a `rosdep`/`set -u` unbound-variable
  crash, and a self-hosted-runner idempotency issue (stale sibling
  checkouts from a previous run).

## Verification

CPU and GPU CI both green on this fork, real runners (one GitHub-hosted,
one self-hosted with an actual GPU) -- not just "builds locally."

## Caveats, disclosed rather than hidden

- GPU CI currently runs on a personal self-hosted runner, not permanent
  shared infra -- fine for proving the pipeline works, not a proposal for
  where it should live long-term.
- This is a personal fork built for my own project's needs, offered
  upstream in case it's useful -- happy to adjust scope/approach based on
  maintainer feedback.